### PR TITLE
Convert controller text to paths

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -61,8 +61,8 @@ io.on 'connection', (socket) ->
 http.on 'error', (err) ->
   switch err.message
     when "listen EACCES"
-      console.error "You dont have permissions to open port", config.port,
-        "For ports smaller than 1024, you need root previleges."
+      console.error "You don't have permissions to open port", config.port,
+        "For ports smaller than 1024, you need root privileges."
   throw err
 
 http.listen config.port, () ->

--- a/main.js
+++ b/main.js
@@ -85,7 +85,7 @@ Virtual gamepad application
   http.on('error', function(err) {
     switch (err.message) {
       case "listen EACCES":
-        console.error("You dont have permissions to open port", config.port, "For ports smaller than 1024, you need root previleges.");
+        console.error("You don't have permissions to open port", config.port, "For ports smaller than 1024, you need root privileges.");
     }
     throw err;
   });

--- a/public/images/SNES_controller.svg
+++ b/public/images/SNES_controller.svg
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -12,14 +13,16 @@
    viewBox="80 100 850 400"
    id="svg2"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
+   inkscape:version="0.48.4 r9939"
    version="1.0"
-   sodipodi:docname="SNES_blank_logo.svg"
+   sodipodi:docname="SNES_controller.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    inkscape:export-filename="C:\Users\Admin\Desktop\snes_ink.bmp.png"
    inkscape:export-xdpi="81"
    inkscape:export-ydpi="81"
-   style="enable-background:new">
+   style="enable-background:new"
+   width="100%"
+   height="100%">
   <sodipodi:namedview
      id="base"
      pagecolor="#7f7f7f"
@@ -31,10 +34,10 @@
      inkscape:pageopacity="0.94901961"
      inkscape:pageshadow="2"
      inkscape:zoom="1"
-     inkscape:cx="504.95687"
-     inkscape:cy="297.95795"
+     inkscape:cx="533.70913"
+     inkscape:cy="296.42339"
      inkscape:document-units="px"
-     inkscape:current-layer="layer3"
+     inkscape:current-layer="layer4"
      showgrid="false"
      width="800px"
      inkscape:showpageshadow="false"
@@ -44,7 +47,8 @@
      inkscape:window-height="750"
      inkscape:window-x="0"
      inkscape:window-y="14"
-     showborder="false">
+     showborder="false"
+     inkscape:window-maximized="0">
     <inkscape:grid
        enabled="true"
        visible="true"
@@ -650,22 +654,6 @@
        inkscape:vp_y="0 : 1000 : 0"
        inkscape:vp_x="0 : 68 : 1"
        sodipodi:type="inkscape:persp3d" />
-    <filter
-       inkscape:collect="always"
-       id="filter5100">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.00033563727"
-         id="feGaussianBlur5102" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       id="filter5112">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.24173957"
-         id="feGaussianBlur5114" />
-    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3566"
@@ -960,79 +948,108 @@
      inkscape:label="Text"
      style="display:inline"
      sodipodi:insensitive="true">
-    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4249"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4689);font-family:Arial;-inkscape-font-specification:Arial"
-       transform="translate(25.5,0)"><flowRegion
-         id="flowRegion4251"><rect
-           id="rect4253"
-           width="74.5"
-           height="30"
-           x="384.5"
-           y="367.5"
-           style="fill:#474b4c;fill-opacity:1;stroke:none;stroke-opacity:1" /></flowRegion><flowPara
-         id="flowPara4255"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#474b4c;fill-opacity:1;stroke:none;stroke-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Italic">SELECT</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4669"
-       style="font-size:16px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4693);font-family:Arial;-inkscape-font-specification:Arial Italic"
-       transform="translate(14,-0.7071068)"><flowRegion
-         id="flowRegion4671"><rect
-           id="rect4673"
-           width="69.650017"
-           height="20.152544"
-           x="490.73212"
-           y="368.06897"
-           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#474b4c;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Italic" /></flowRegion><flowPara
-         id="flowPara4675"
-         style="font-size:16px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#474b4c;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Italic">START</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4186"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4713);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,178.84196,53.480205)"><flowRegion
-         id="flowRegion4188"><rect
-           id="rect4190"
-           width="42.426407"
-           height="37.476658"
-           x="839.33575"
-           y="246.80016"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4192">A</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4194"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4709);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,141.21719,80.844545)"><flowRegion
-         id="flowRegion4196"><rect
-           id="rect4198"
-           width="44.547726"
-           height="40.658642"
-           x="695.08594"
-           y="388.92862"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4200">B</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4202"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4701);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,125.0875,66.207045)"><flowRegion
-         id="flowRegion4204"><rect
-           id="rect4206"
-           width="39.244427"
-           height="35.001785"
-           x="614.82935"
-           y="315.74307"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4208">Y</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4210"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4697);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,155.28437,37.707045)"><flowRegion
-         id="flowRegion4212"><rect
-           id="rect4214"
-           width="44.547726"
-           height="39.59798"
-           x="765.79663"
-           y="173.26106"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4216">X</flowPara></flowRoot>  </g>
+    <g
+       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;filter:url(#filter4689);font-family:Arial;-inkscape-font-specification:Arial"
+       id="text3161">
+      <path
+         d="m 414.8125,383.40146 c -0.67709,0 -1.27084,-0.0599 -1.78125,-0.17969 -0.50521,-0.125 -0.9349,-0.30469 -1.28906,-0.53906 -0.35417,-0.23958 -0.63802,-0.53125 -0.85157,-0.875 -0.20833,-0.34896 -0.35416,-0.75 -0.4375,-1.20313 l 1.38282,-0.28906 c 0.0677,0.32292 0.17447,0.60417 0.32031,0.84375 0.14583,0.23959 0.34114,0.44011 0.58594,0.60156 0.24479,0.15626 0.54687,0.27344 0.90625,0.35157 0.35937,0.0781 0.78385,0.11718 1.27343,0.11718 0.51042,0 0.96875,-0.0338 1.375,-0.10156 0.40625,-0.0729 0.75,-0.1901 1.03125,-0.35156 0.28646,-0.16667 0.50521,-0.38021 0.65625,-0.64063 0.15104,-0.26562 0.22656,-0.59374 0.22657,-0.98437 -10e-6,-0.26562 -0.0443,-0.49219 -0.13282,-0.67969 -0.0885,-0.18749 -0.24219,-0.35416 -0.46093,-0.5 -0.21876,-0.15104 -0.51563,-0.29166 -0.89063,-0.42187 -0.3698,-0.13542 -0.83594,-0.28125 -1.39844,-0.4375 -0.45833,-0.125 -0.89062,-0.26302 -1.29687,-0.41407 -0.40105,-0.15624 -0.75261,-0.34634 -1.05469,-0.57031 -0.30208,-0.22916 -0.54167,-0.5052 -0.71875,-0.82812 -0.17708,-0.32291 -0.26562,-0.71875 -0.26562,-1.1875 0,-0.54687 0.12239,-1.01041 0.36718,-1.39063 0.25,-0.38541 0.58073,-0.70051 0.99219,-0.94531 0.41667,-0.24478 0.89062,-0.42187 1.42188,-0.53125 0.53645,-0.11457 1.09114,-0.17187 1.66406,-0.17188 0.6302,10e-6 1.17968,0.0573 1.64844,0.17188 0.47395,0.11459 0.87499,0.27605 1.20312,0.48437 0.33333,0.20314 0.59895,0.44793 0.79688,0.73438 0.1979,0.28647 0.33592,0.59897 0.41406,0.9375 l -1.35156,0.39844 c -0.0781,-0.25 -0.18751,-0.47395 -0.32813,-0.67188 -0.14063,-0.19791 -0.32032,-0.36457 -0.53906,-0.5 -0.21876,-0.14061 -0.48178,-0.24738 -0.78906,-0.32031 -0.30209,-0.0729 -0.65626,-0.10937 -1.0625,-0.10938 -0.54168,10e-6 -1.00001,0.0469 -1.375,0.14063 -0.3698,0.0885 -0.67188,0.21615 -0.90625,0.38281 -0.22917,0.16147 -0.39584,0.35678 -0.5,0.58594 -0.10417,0.22397 -0.15626,0.46876 -0.15625,0.73437 -10e-6,0.28126 0.0521,0.51564 0.15625,0.70313 0.10937,0.1823 0.27343,0.33855 0.49218,0.46875 0.21875,0.13021 0.49479,0.25001 0.82813,0.35937 0.33854,0.10418 0.73697,0.21876 1.19531,0.34375 0.45312,0.12501 0.89322,0.26303 1.32031,0.41407 0.43229,0.15104 0.8151,0.34375 1.14844,0.57812 0.33333,0.22917 0.59895,0.51563 0.79688,0.85938 0.20311,0.34375 0.30468,0.77344 0.30468,1.28906 0,1.07292 -0.40365,1.89844 -1.21093,2.47656 -0.8073,0.57813 -2.04428,0.86719 -3.71094,0.86719"
+         style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3164"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 421.17969,383.24521 2.13281,-11.00781 8.19531,0 -0.23437,1.21875 -6.70313,0 -0.6875,3.53125 6.23438,0 -0.23438,1.20312 -6.23437,0 -0.74219,3.83594 7.02344,0 -0.23438,1.21875 -8.51562,0"
+         style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3166"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 431.86719,383.24521 434,372.2374 l 1.49219,0 -1.89844,9.78906 5.5625,0 -0.23438,1.21875 -7.05468,0"
+         style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3168"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 440.77344,383.24521 2.13281,-11.00781 8.19531,0 -0.23437,1.21875 -6.70313,0 -0.6875,3.53125 6.23438,0 -0.23438,1.20312 -6.23437,0 -0.74219,3.83594 7.02344,0 -0.23438,1.21875 -8.51562,0"
+         style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3170"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 461.57812,380.6124 c -0.25521,0.38021 -0.54167,0.73958 -0.85937,1.07812 -0.31772,0.33854 -0.6823,0.63542 -1.09375,0.89063 -0.40626,0.25 -0.8724,0.45052 -1.39844,0.60156 -0.52084,0.14583 -1.11719,0.21875 -1.78906,0.21875 -0.77084,0 -1.44532,-0.11979 -2.02344,-0.35938 -0.57292,-0.23958 -1.04948,-0.5651 -1.42969,-0.97656 -0.3802,-0.41666 -0.66406,-0.90364 -0.85156,-1.46094 -0.1875,-0.56249 -0.28125,-1.16405 -0.28125,-1.80468 0,-0.64583 0.0703,-1.26041 0.21094,-1.84375 0.14062,-0.58333 0.34114,-1.12239 0.60156,-1.61719 0.26042,-0.49999 0.57813,-0.95051 0.95313,-1.35156 0.37499,-0.40624 0.79687,-0.74999 1.26562,-1.03125 0.47396,-0.28124 0.98958,-0.49739 1.54688,-0.64844 0.55728,-0.15624 1.14843,-0.23437 1.77343,-0.23438 0.67187,10e-6 1.26041,0.0781 1.76563,0.23438 0.5052,0.15105 0.93749,0.35157 1.29687,0.60156 0.35937,0.25001 0.64843,0.53647 0.86719,0.85938 0.21874,0.32292 0.3776,0.65626 0.47656,1 l -1.40625,0.42968 c -0.0781,-0.24478 -0.19792,-0.47915 -0.35937,-0.70312 -0.16147,-0.22916 -0.3698,-0.43228 -0.625,-0.60938 -0.25001,-0.18228 -0.54949,-0.32551 -0.89844,-0.42968 -0.34376,-0.10937 -0.74219,-0.16406 -1.19531,-0.16407 -0.76042,10e-6 -1.43751,0.14064 -2.03125,0.42188 -0.59375,0.27605 -1.09636,0.66147 -1.50781,1.15625 -0.41146,0.48959 -0.72396,1.07292 -0.9375,1.75 -0.21355,0.67188 -0.32032,1.40625 -0.32032,2.20312 0,0.48959 0.0677,0.94011 0.20313,1.35157 0.13541,0.41146 0.33593,0.76823 0.60156,1.07031 0.27083,0.29688 0.60677,0.52865 1.00781,0.69531 0.40104,0.16667 0.86719,0.25 1.39844,0.25 0.46875,0 0.89843,-0.0625 1.28906,-0.1875 0.39062,-0.13021 0.74739,-0.29948 1.07032,-0.50781 0.32811,-0.21354 0.61978,-0.45573 0.875,-0.72656 0.26041,-0.27604 0.48957,-0.5599 0.6875,-0.85157 l 1.11718,0.69532"
+         style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3172"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 469.23437,373.45615 -1.90625,9.78906 -1.48437,0 1.90625,-9.78906 -3.78125,0 0.23437,-1.21875 9.04688,0 -0.23438,1.21875 -3.78125,0"
+         style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3174"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       style="font-size:16px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4693);font-family:Arial;-inkscape-font-specification:Arial Italic"
+       id="text3167">
+      <path
+         d="m 509.53125,383.25687 c -0.67709,0 -1.27084,-0.0599 -1.78125,-0.17969 -0.50521,-0.125 -0.9349,-0.30469 -1.28906,-0.53906 -0.35417,-0.23959 -0.63802,-0.53125 -0.85157,-0.875 -0.20833,-0.34896 -0.35416,-0.75 -0.4375,-1.20313 l 1.38282,-0.28906 c 0.0677,0.32292 0.17447,0.60417 0.32031,0.84375 0.14583,0.23958 0.34114,0.4401 0.58594,0.60156 0.24479,0.15625 0.54687,0.27344 0.90625,0.35156 0.35937,0.0781 0.78385,0.11719 1.27343,0.11719 0.51042,0 0.96875,-0.0339 1.375,-0.10156 0.40625,-0.0729 0.75,-0.1901 1.03125,-0.35156 0.28646,-0.16667 0.50521,-0.38021 0.65625,-0.64063 0.15104,-0.26562 0.22656,-0.59375 0.22657,-0.98437 -1e-5,-0.26563 -0.0443,-0.49219 -0.13282,-0.67969 -0.0885,-0.1875 -0.24219,-0.35416 -0.46093,-0.5 -0.21876,-0.15104 -0.51563,-0.29166 -0.89063,-0.42188 -0.3698,-0.13541 -0.83594,-0.28124 -1.39844,-0.4375 -0.45833,-0.12499 -0.89062,-0.26301 -1.29687,-0.41406 -0.40105,-0.15624 -0.75261,-0.34635 -1.05469,-0.57031 -0.30208,-0.22916 -0.54167,-0.5052 -0.71875,-0.82813 -0.17708,-0.32291 -0.26562,-0.71874 -0.26562,-1.1875 0,-0.54686 0.12239,-1.0104 0.36718,-1.39062 0.25,-0.38541 0.58073,-0.70051 0.99219,-0.94531 0.41667,-0.24478 0.89062,-0.42187 1.42188,-0.53125 0.53645,-0.11458 1.09114,-0.17187 1.66406,-0.17188 0.6302,10e-6 1.17968,0.0573 1.64844,0.17188 0.47395,0.11459 0.87499,0.27605 1.20312,0.48437 0.33333,0.20314 0.59895,0.44793 0.79688,0.73438 0.1979,0.28646 0.33592,0.59896 0.41406,0.9375 l -1.35156,0.39843 c -0.0781,-0.24999 -0.18751,-0.47395 -0.32813,-0.67187 -0.14063,-0.19791 -0.32032,-0.36457 -0.53906,-0.5 -0.21876,-0.14062 -0.48178,-0.24739 -0.78906,-0.32031 -0.30209,-0.0729 -0.65626,-0.10937 -1.0625,-0.10938 -0.54168,10e-6 -1.00001,0.0469 -1.375,0.14063 -0.3698,0.0885 -0.67188,0.21615 -0.90625,0.38281 -0.22917,0.16147 -0.39584,0.35678 -0.5,0.58594 -0.10417,0.22396 -0.15626,0.46875 -0.15625,0.73437 -10e-6,0.28126 0.0521,0.51563 0.15625,0.70313 0.10937,0.1823 0.27343,0.33855 0.49218,0.46875 0.21875,0.13021 0.49479,0.25 0.82813,0.35937 0.33854,0.10417 0.73697,0.21876 1.19531,0.34375 0.45312,0.12501 0.89322,0.26303 1.32031,0.41406 0.43229,0.15105 0.8151,0.34376 1.14844,0.57813 0.33333,0.22917 0.59895,0.51563 0.79688,0.85937 0.20311,0.34376 0.30468,0.77345 0.30468,1.28907 0,1.07292 -0.40365,1.89844 -1.21093,2.47656 -0.8073,0.57812 -2.04428,0.86719 -3.71094,0.86719"
+         style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3177"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 522.10937,373.31155 -1.90625,9.78907 -1.48437,0 1.90625,-9.78907 -3.78125,0 0.23437,-1.21875 9.04688,0 -0.23438,1.21875 -3.78125,0"
+         style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3179"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 532.28906,383.10062 -0.58594,-3.21875 -4.99218,0 -1.875,3.21875 -1.625,0 6.625,-11.00782 1.69531,0 2.28125,11.00782 -1.52344,0 m -1.48437,-8.07813 c -0.0417,-0.21353 -0.0833,-0.42187 -0.125,-0.625 -0.0365,-0.20311 -0.0677,-0.38801 -0.0937,-0.55469 -0.0261,-0.17186 -0.0495,-0.31249 -0.0703,-0.42187 -0.0156,-0.11457 -0.026,-0.18228 -0.0312,-0.20313 -0.0104,0.0208 -0.0469,0.0886 -0.10937,0.20313 -0.0573,0.11459 -0.13282,0.25782 -0.22656,0.42969 -0.0938,0.16667 -0.19793,0.35417 -0.3125,0.5625 -0.11459,0.20313 -0.23438,0.40886 -0.35938,0.61718 l -2.10937,3.6875 4.11718,0 -0.67968,-3.69531"
+         style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3181"
+         inkscape:connector-curvature="0" />
+      <path
+         d="M 542.89844,383.10062 541,378.5303 l -3.44531,0 -0.88282,4.57032 -1.49218,0 2.13281,-11.00782 4.78125,0 c 0.54166,10e-6 1.03645,0.0677 1.48437,0.20313 0.44791,0.13022 0.83072,0.32032 1.14844,0.57031 0.32291,0.25001 0.57291,0.5547 0.75,0.91406 0.18228,0.35418 0.27343,0.75522 0.27344,1.20313 -10e-6,0.97917 -0.28126,1.75521 -0.84375,2.32812 -0.56251,0.57293 -1.39324,0.9349 -2.49219,1.08594 l 2.09375,4.70313 -1.60937,0 m -1.51563,-5.75 c 0.9427,0 1.65364,-0.19531 2.13281,-0.58594 0.47916,-0.39583 0.71875,-0.95051 0.71875,-1.66406 0,-0.58333 -0.19532,-1.03124 -0.58593,-1.34375 -0.38543,-0.31249 -0.96355,-0.46874 -1.73438,-0.46875 l -3.33594,0 -0.78906,4.0625 3.59375,0"
+         style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3183"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 552.67187,373.31155 -1.90625,9.78907 -1.48437,0 1.90625,-9.78907 -3.78125,0 0.23437,-1.21875 9.04688,0 -0.23438,1.21875 -3.78125,0"
+         style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+         id="path3185"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(0.8,0,0,0.8,178.84196,53.480205)"
+       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4713);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+       id="text3173">
+      <path
+         d="m 854.75391,273.17004 -7.5586,0 -1.04004,3.54493 -6.78222,0 8.07129,-21.47461 7.23632,0 8.07129,21.47461 -6.94336,0 -1.05468,-3.54493 m -1.39161,-4.64355 -2.37304,-7.71973 -2.3584,7.71973 4.73144,0"
+         style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+         id="path3158"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(0.8,0,0,0.8,141.21719,80.844545)"
+       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4709);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+       id="text3185">
+      <path
+         d="m 697.30566,397.36536 12.42188,0 c 2.07029,2e-5 3.65721,0.51271 4.76074,1.53808 1.11326,1.02541 1.6699,2.29494 1.66992,3.8086 -2e-5,1.26954 -0.39553,2.35841 -1.18652,3.2666 -0.52736,0.60548 -1.29885,1.08399 -2.31445,1.43554 1.54295,0.37111 2.67576,1.01076 3.39843,1.91895 0.7324,0.89845 1.09861,2.03126 1.09864,3.39844 -3e-5,1.11328 -0.25881,2.11426 -0.77637,3.00293 -0.5176,0.88867 -1.22561,1.5918 -2.12402,2.10937 -0.55666,0.32227 -1.39651,0.55664 -2.51954,0.70313 -1.49415,0.19531 -2.48536,0.29297 -2.97363,0.29297 l -11.45508,0 0,-21.47461 m 6.69434,8.42285 2.88574,0 c 1.03515,1e-5 1.75292,-0.17577 2.15332,-0.52735 0.41014,-0.36131 0.61522,-0.87889 0.61524,-1.55273 -2e-5,-0.62498 -0.2051,-1.11327 -0.61524,-1.46484 -0.4004,-0.35155 -1.10353,-0.52733 -2.10937,-0.52735 l -2.92969,0 0,4.07227 m 0,8.4375 3.38379,0 c 1.14256,0 1.94823,-0.20019 2.41699,-0.60059 0.46874,-0.41015 0.70311,-0.95702 0.70313,-1.64062 -2e-5,-0.63476 -0.23439,-1.14257 -0.70313,-1.52344 -0.459,-0.39062 -1.26954,-0.58593 -2.43164,-0.58594 l -3.36914,0 0,4.35059"
+         style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+         id="path3155"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(0.8,0,0,0.8,125.0875,66.207045)"
+       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4701);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+       id="text3191">
+      <path
+         d="m 614.87305,324.17786 7.36816,0 4.33594,7.25097 4.33594,-7.25097 7.32421,0 -8.3496,12.48047 0,8.99414 -6.6504,0 0,-8.99414 -8.36425,-12.48047"
+         style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+         id="path3152"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="matrix(0.8,0,0,0.8,155.28437,37.707045)"
+       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4697);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+       id="text3179">
+      <path
+         d="m 766.49902,181.67786 7.30957,0 3.8086,6.60644 3.6914,-6.60644 7.23633,0 -6.67969,10.40039 7.30957,11.07422 -7.45605,0 -4.2334,-6.89942 -4.24805,6.89942 -7.4121,0 7.4121,-11.19141 -6.73828,-10.2832"
+         style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+         id="path3161"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
 </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -1,22 +1,18 @@
 <html>
-	<head>
-		<title>Virtual gamepad</title>
+    <head>
+        <title>Virtual gamepad</title>
         <link rel="icon" type="image/png" href="/images/icons/favicon_32.png" />
         <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
         <link rel="manifest" href="manifest.json">
         <meta name="mobile-web-app-capable" content="yes">
         <link rel="icon" sizes="192x192" href="images/icons/launcher-icon-4x.png">
-		<script src="js/lib/jquery.js"></script>
-		<script src="js/lib/socketio.js"></script>
+        <script src="js/lib/jquery.js"></script>
+        <script src="js/lib/socketio.js"></script>
         <script src="js/virtualjoystick.js"></script>
         <script src="js/virtual_gamepad_client.js"></script>
         <link rel="stylesheet" type="text/css" href="css/style.css">
-	</head>
-	<body>
-        <!--viewBox="80 100 850 400"-->
-        <!--viewBox="0 0 1000 600"-->
-        <!--path3214-->
-
+    </head>
+    <body>
         <div id="slotIndicatorContainer">
             <table id="tableIndicator">
                 <tr>
@@ -1049,81 +1045,110 @@
                     inkscape:label="Text"
                     style="display:inline"
                     sodipodi:insensitive="true">
-                <flowRoot
-       xml:space="preserve"
-       id="flowRoot4249"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;filter:url(#filter4689);font-family:Arial;-inkscape-font-specification:Arial"
-       transform="translate(25.5,0)"><flowRegion
-         id="flowRegion4251"><rect
-           id="rect4253"
-           width="74.5"
-           height="30"
-           x="384.5"
-           y="367.5"
-           style="fill:#474b4c;fill-opacity:1;stroke:none;stroke-opacity:1" /></flowRegion><flowPara
-         id="flowPara4255"
-         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#474b4c;fill-opacity:1;stroke:none;stroke-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Italic">SELECT</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4669"
-       style="font-size:16px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4693);font-family:Arial;-inkscape-font-specification:Arial Italic"
-       transform="translate(14,-0.7071068)"><flowRegion
-         id="flowRegion4671"><rect
-           id="rect4673"
-           width="69.650017"
-           height="20.152544"
-           x="490.73212"
-           y="368.06897"
-           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#474b4c;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Italic" /></flowRegion><flowPara
-         id="flowPara4675"
-         style="font-size:16px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#474b4c;fill-opacity:1;font-family:Arial;-inkscape-font-specification:Arial Italic">START</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4186"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4713);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,178.84196,53.480205)"><flowRegion
-         id="flowRegion4188"><rect
-           id="rect4190"
-           width="42.426407"
-           height="37.476658"
-           x="839.33575"
-           y="246.80016"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4192">A</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4194"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4709);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,141.21719,80.844545)"><flowRegion
-         id="flowRegion4196"><rect
-           id="rect4198"
-           width="44.547726"
-           height="40.658642"
-           x="695.08594"
-           y="388.92862"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4200">B</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4202"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4701);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,125.0875,66.207045)"><flowRegion
-         id="flowRegion4204"><rect
-           id="rect4206"
-           width="39.244427"
-           height="35.001785"
-           x="614.82935"
-           y="315.74307"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4208">Y</flowPara></flowRoot>    <flowRoot
-       xml:space="preserve"
-       id="flowRoot4210"
-       style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;display:inline;filter:url(#filter4697);font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy"
-       transform="matrix(0.8,0,0,0.8,155.28437,37.707045)"><flowRegion
-         id="flowRegion4212"><rect
-           id="rect4214"
-           width="44.547726"
-           height="39.59798"
-           x="765.79663"
-           y="173.26106"
-           style="font-size:30px;font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;font-family:Arial Black;-inkscape-font-specification:Arial Black Heavy" /></flowRegion><flowPara
-         id="flowPara4216">X</flowPara></flowRoot>  </g>
+                <g
+                        style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;filter:url(#filter4689);font-family:Arial;-inkscape-font-specification:Arial"
+                        id="text3161">
+                    <path
+                            d="m 414.8125,383.40146 c -0.67709,0 -1.27084,-0.0599 -1.78125,-0.17969 -0.50521,-0.125 -0.9349,-0.30469 -1.28906,-0.53906 -0.35417,-0.23958 -0.63802,-0.53125 -0.85157,-0.875 -0.20833,-0.34896 -0.35416,-0.75 -0.4375,-1.20313 l 1.38282,-0.28906 c 0.0677,0.32292 0.17447,0.60417 0.32031,0.84375 0.14583,0.23959 0.34114,0.44011 0.58594,0.60156 0.24479,0.15626 0.54687,0.27344 0.90625,0.35157 0.35937,0.0781 0.78385,0.11718 1.27343,0.11718 0.51042,0 0.96875,-0.0338 1.375,-0.10156 0.40625,-0.0729 0.75,-0.1901 1.03125,-0.35156 0.28646,-0.16667 0.50521,-0.38021 0.65625,-0.64063 0.15104,-0.26562 0.22656,-0.59374 0.22657,-0.98437 -10e-6,-0.26562 -0.0443,-0.49219 -0.13282,-0.67969 -0.0885,-0.18749 -0.24219,-0.35416 -0.46093,-0.5 -0.21876,-0.15104 -0.51563,-0.29166 -0.89063,-0.42187 -0.3698,-0.13542 -0.83594,-0.28125 -1.39844,-0.4375 -0.45833,-0.125 -0.89062,-0.26302 -1.29687,-0.41407 -0.40105,-0.15624 -0.75261,-0.34634 -1.05469,-0.57031 -0.30208,-0.22916 -0.54167,-0.5052 -0.71875,-0.82812 -0.17708,-0.32291 -0.26562,-0.71875 -0.26562,-1.1875 0,-0.54687 0.12239,-1.01041 0.36718,-1.39063 0.25,-0.38541 0.58073,-0.70051 0.99219,-0.94531 0.41667,-0.24478 0.89062,-0.42187 1.42188,-0.53125 0.53645,-0.11457 1.09114,-0.17187 1.66406,-0.17188 0.6302,10e-6 1.17968,0.0573 1.64844,0.17188 0.47395,0.11459 0.87499,0.27605 1.20312,0.48437 0.33333,0.20314 0.59895,0.44793 0.79688,0.73438 0.1979,0.28647 0.33592,0.59897 0.41406,0.9375 l -1.35156,0.39844 c -0.0781,-0.25 -0.18751,-0.47395 -0.32813,-0.67188 -0.14063,-0.19791 -0.32032,-0.36457 -0.53906,-0.5 -0.21876,-0.14061 -0.48178,-0.24738 -0.78906,-0.32031 -0.30209,-0.0729 -0.65626,-0.10937 -1.0625,-0.10938 -0.54168,10e-6 -1.00001,0.0469 -1.375,0.14063 -0.3698,0.0885 -0.67188,0.21615 -0.90625,0.38281 -0.22917,0.16147 -0.39584,0.35678 -0.5,0.58594 -0.10417,0.22397 -0.15626,0.46876 -0.15625,0.73437 -10e-6,0.28126 0.0521,0.51564 0.15625,0.70313 0.10937,0.1823 0.27343,0.33855 0.49218,0.46875 0.21875,0.13021 0.49479,0.25001 0.82813,0.35937 0.33854,0.10418 0.73697,0.21876 1.19531,0.34375 0.45312,0.12501 0.89322,0.26303 1.32031,0.41407 0.43229,0.15104 0.8151,0.34375 1.14844,0.57812 0.33333,0.22917 0.59895,0.51563 0.79688,0.85938 0.20311,0.34375 0.30468,0.77344 0.30468,1.28906 0,1.07292 -0.40365,1.89844 -1.21093,2.47656 -0.8073,0.57813 -2.04428,0.86719 -3.71094,0.86719"
+                            style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3164"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 421.17969,383.24521 2.13281,-11.00781 8.19531,0 -0.23437,1.21875 -6.70313,0 -0.6875,3.53125 6.23438,0 -0.23438,1.20312 -6.23437,0 -0.74219,3.83594 7.02344,0 -0.23438,1.21875 -8.51562,0"
+                            style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3166"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="M 431.86719,383.24521 434,372.2374 l 1.49219,0 -1.89844,9.78906 5.5625,0 -0.23438,1.21875 -7.05468,0"
+                            style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3168"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 440.77344,383.24521 2.13281,-11.00781 8.19531,0 -0.23437,1.21875 -6.70313,0 -0.6875,3.53125 6.23438,0 -0.23438,1.20312 -6.23437,0 -0.74219,3.83594 7.02344,0 -0.23438,1.21875 -8.51562,0"
+                            style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3170"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 461.57812,380.6124 c -0.25521,0.38021 -0.54167,0.73958 -0.85937,1.07812 -0.31772,0.33854 -0.6823,0.63542 -1.09375,0.89063 -0.40626,0.25 -0.8724,0.45052 -1.39844,0.60156 -0.52084,0.14583 -1.11719,0.21875 -1.78906,0.21875 -0.77084,0 -1.44532,-0.11979 -2.02344,-0.35938 -0.57292,-0.23958 -1.04948,-0.5651 -1.42969,-0.97656 -0.3802,-0.41666 -0.66406,-0.90364 -0.85156,-1.46094 -0.1875,-0.56249 -0.28125,-1.16405 -0.28125,-1.80468 0,-0.64583 0.0703,-1.26041 0.21094,-1.84375 0.14062,-0.58333 0.34114,-1.12239 0.60156,-1.61719 0.26042,-0.49999 0.57813,-0.95051 0.95313,-1.35156 0.37499,-0.40624 0.79687,-0.74999 1.26562,-1.03125 0.47396,-0.28124 0.98958,-0.49739 1.54688,-0.64844 0.55728,-0.15624 1.14843,-0.23437 1.77343,-0.23438 0.67187,10e-6 1.26041,0.0781 1.76563,0.23438 0.5052,0.15105 0.93749,0.35157 1.29687,0.60156 0.35937,0.25001 0.64843,0.53647 0.86719,0.85938 0.21874,0.32292 0.3776,0.65626 0.47656,1 l -1.40625,0.42968 c -0.0781,-0.24478 -0.19792,-0.47915 -0.35937,-0.70312 -0.16147,-0.22916 -0.3698,-0.43228 -0.625,-0.60938 -0.25001,-0.18228 -0.54949,-0.32551 -0.89844,-0.42968 -0.34376,-0.10937 -0.74219,-0.16406 -1.19531,-0.16407 -0.76042,10e-6 -1.43751,0.14064 -2.03125,0.42188 -0.59375,0.27605 -1.09636,0.66147 -1.50781,1.15625 -0.41146,0.48959 -0.72396,1.07292 -0.9375,1.75 -0.21355,0.67188 -0.32032,1.40625 -0.32032,2.20312 0,0.48959 0.0677,0.94011 0.20313,1.35157 0.13541,0.41146 0.33593,0.76823 0.60156,1.07031 0.27083,0.29688 0.60677,0.52865 1.00781,0.69531 0.40104,0.16667 0.86719,0.25 1.39844,0.25 0.46875,0 0.89843,-0.0625 1.28906,-0.1875 0.39062,-0.13021 0.74739,-0.29948 1.07032,-0.50781 0.32811,-0.21354 0.61978,-0.45573 0.875,-0.72656 0.26041,-0.27604 0.48957,-0.5599 0.6875,-0.85157 l 1.11718,0.69532"
+                            style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3172"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 469.23437,373.45615 -1.90625,9.78906 -1.48437,0 1.90625,-9.78906 -3.78125,0 0.23437,-1.21875 9.04688,0 -0.23438,1.21875 -3.78125,0"
+                            style="font-style:italic;fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3174"
+                            inkscape:connector-curvature="0" />
+                </g>
+                <g
+                        style="font-size:16px;font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#474b4c;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4693);font-family:Arial;-inkscape-font-specification:Arial Italic"
+                        id="text3167">
+                    <path
+                            d="m 509.53125,383.25687 c -0.67709,0 -1.27084,-0.0599 -1.78125,-0.17969 -0.50521,-0.125 -0.9349,-0.30469 -1.28906,-0.53906 -0.35417,-0.23959 -0.63802,-0.53125 -0.85157,-0.875 -0.20833,-0.34896 -0.35416,-0.75 -0.4375,-1.20313 l 1.38282,-0.28906 c 0.0677,0.32292 0.17447,0.60417 0.32031,0.84375 0.14583,0.23958 0.34114,0.4401 0.58594,0.60156 0.24479,0.15625 0.54687,0.27344 0.90625,0.35156 0.35937,0.0781 0.78385,0.11719 1.27343,0.11719 0.51042,0 0.96875,-0.0339 1.375,-0.10156 0.40625,-0.0729 0.75,-0.1901 1.03125,-0.35156 0.28646,-0.16667 0.50521,-0.38021 0.65625,-0.64063 0.15104,-0.26562 0.22656,-0.59375 0.22657,-0.98437 -1e-5,-0.26563 -0.0443,-0.49219 -0.13282,-0.67969 -0.0885,-0.1875 -0.24219,-0.35416 -0.46093,-0.5 -0.21876,-0.15104 -0.51563,-0.29166 -0.89063,-0.42188 -0.3698,-0.13541 -0.83594,-0.28124 -1.39844,-0.4375 -0.45833,-0.12499 -0.89062,-0.26301 -1.29687,-0.41406 -0.40105,-0.15624 -0.75261,-0.34635 -1.05469,-0.57031 -0.30208,-0.22916 -0.54167,-0.5052 -0.71875,-0.82813 -0.17708,-0.32291 -0.26562,-0.71874 -0.26562,-1.1875 0,-0.54686 0.12239,-1.0104 0.36718,-1.39062 0.25,-0.38541 0.58073,-0.70051 0.99219,-0.94531 0.41667,-0.24478 0.89062,-0.42187 1.42188,-0.53125 0.53645,-0.11458 1.09114,-0.17187 1.66406,-0.17188 0.6302,10e-6 1.17968,0.0573 1.64844,0.17188 0.47395,0.11459 0.87499,0.27605 1.20312,0.48437 0.33333,0.20314 0.59895,0.44793 0.79688,0.73438 0.1979,0.28646 0.33592,0.59896 0.41406,0.9375 l -1.35156,0.39843 c -0.0781,-0.24999 -0.18751,-0.47395 -0.32813,-0.67187 -0.14063,-0.19791 -0.32032,-0.36457 -0.53906,-0.5 -0.21876,-0.14062 -0.48178,-0.24739 -0.78906,-0.32031 -0.30209,-0.0729 -0.65626,-0.10937 -1.0625,-0.10938 -0.54168,10e-6 -1.00001,0.0469 -1.375,0.14063 -0.3698,0.0885 -0.67188,0.21615 -0.90625,0.38281 -0.22917,0.16147 -0.39584,0.35678 -0.5,0.58594 -0.10417,0.22396 -0.15626,0.46875 -0.15625,0.73437 -10e-6,0.28126 0.0521,0.51563 0.15625,0.70313 0.10937,0.1823 0.27343,0.33855 0.49218,0.46875 0.21875,0.13021 0.49479,0.25 0.82813,0.35937 0.33854,0.10417 0.73697,0.21876 1.19531,0.34375 0.45312,0.12501 0.89322,0.26303 1.32031,0.41406 0.43229,0.15105 0.8151,0.34376 1.14844,0.57813 0.33333,0.22917 0.59895,0.51563 0.79688,0.85937 0.20311,0.34376 0.30468,0.77345 0.30468,1.28907 0,1.07292 -0.40365,1.89844 -1.21093,2.47656 -0.8073,0.57812 -2.04428,0.86719 -3.71094,0.86719"
+                            style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3177"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 522.10937,373.31155 -1.90625,9.78907 -1.48437,0 1.90625,-9.78907 -3.78125,0 0.23437,-1.21875 9.04688,0 -0.23438,1.21875 -3.78125,0"
+                            style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3179"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 532.28906,383.10062 -0.58594,-3.21875 -4.99218,0 -1.875,3.21875 -1.625,0 6.625,-11.00782 1.69531,0 2.28125,11.00782 -1.52344,0 m -1.48437,-8.07813 c -0.0417,-0.21353 -0.0833,-0.42187 -0.125,-0.625 -0.0365,-0.20311 -0.0677,-0.38801 -0.0937,-0.55469 -0.0261,-0.17186 -0.0495,-0.31249 -0.0703,-0.42187 -0.0156,-0.11457 -0.026,-0.18228 -0.0312,-0.20313 -0.0104,0.0208 -0.0469,0.0886 -0.10937,0.20313 -0.0573,0.11459 -0.13282,0.25782 -0.22656,0.42969 -0.0938,0.16667 -0.19793,0.35417 -0.3125,0.5625 -0.11459,0.20313 -0.23438,0.40886 -0.35938,0.61718 l -2.10937,3.6875 4.11718,0 -0.67968,-3.69531"
+                            style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3181"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="M 542.89844,383.10062 541,378.5303 l -3.44531,0 -0.88282,4.57032 -1.49218,0 2.13281,-11.00782 4.78125,0 c 0.54166,10e-6 1.03645,0.0677 1.48437,0.20313 0.44791,0.13022 0.83072,0.32032 1.14844,0.57031 0.32291,0.25001 0.57291,0.5547 0.75,0.91406 0.18228,0.35418 0.27343,0.75522 0.27344,1.20313 -10e-6,0.97917 -0.28126,1.75521 -0.84375,2.32812 -0.56251,0.57293 -1.39324,0.9349 -2.49219,1.08594 l 2.09375,4.70313 -1.60937,0 m -1.51563,-5.75 c 0.9427,0 1.65364,-0.19531 2.13281,-0.58594 0.47916,-0.39583 0.71875,-0.95051 0.71875,-1.66406 0,-0.58333 -0.19532,-1.03124 -0.58593,-1.34375 -0.38543,-0.31249 -0.96355,-0.46874 -1.73438,-0.46875 l -3.33594,0 -0.78906,4.0625 3.59375,0"
+                            style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3183"
+                            inkscape:connector-curvature="0" />
+                    <path
+                            d="m 552.67187,373.31155 -1.90625,9.78907 -1.48437,0 1.90625,-9.78907 -3.78125,0 0.23437,-1.21875 9.04688,0 -0.23438,1.21875 -3.78125,0"
+                            style="fill:#474b4c;font-family:Arial;-inkscape-font-specification:Arial Italic"
+                            id="path3185"
+                            inkscape:connector-curvature="0" />
+                </g>
+                <g
+                        transform="matrix(0.8,0,0,0.8,178.84196,53.480205)"
+                        style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4713);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+                        id="text3173">
+                    <path
+                            d="m 854.75391,273.17004 -7.5586,0 -1.04004,3.54493 -6.78222,0 8.07129,-21.47461 7.23632,0 8.07129,21.47461 -6.94336,0 -1.05468,-3.54493 m -1.39161,-4.64355 -2.37304,-7.71973 -2.3584,7.71973 4.73144,0"
+                            style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+                            id="path3158"
+                            inkscape:connector-curvature="0" />
+                </g>
+                <g
+                        transform="matrix(0.8,0,0,0.8,141.21719,80.844545)"
+                        style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4709);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+                        id="text3185">
+                    <path
+                            d="m 697.30566,397.36536 12.42188,0 c 2.07029,2e-5 3.65721,0.51271 4.76074,1.53808 1.11326,1.02541 1.6699,2.29494 1.66992,3.8086 -2e-5,1.26954 -0.39553,2.35841 -1.18652,3.2666 -0.52736,0.60548 -1.29885,1.08399 -2.31445,1.43554 1.54295,0.37111 2.67576,1.01076 3.39843,1.91895 0.7324,0.89845 1.09861,2.03126 1.09864,3.39844 -3e-5,1.11328 -0.25881,2.11426 -0.77637,3.00293 -0.5176,0.88867 -1.22561,1.5918 -2.12402,2.10937 -0.55666,0.32227 -1.39651,0.55664 -2.51954,0.70313 -1.49415,0.19531 -2.48536,0.29297 -2.97363,0.29297 l -11.45508,0 0,-21.47461 m 6.69434,8.42285 2.88574,0 c 1.03515,1e-5 1.75292,-0.17577 2.15332,-0.52735 0.41014,-0.36131 0.61522,-0.87889 0.61524,-1.55273 -2e-5,-0.62498 -0.2051,-1.11327 -0.61524,-1.46484 -0.4004,-0.35155 -1.10353,-0.52733 -2.10937,-0.52735 l -2.92969,0 0,4.07227 m 0,8.4375 3.38379,0 c 1.14256,0 1.94823,-0.20019 2.41699,-0.60059 0.46874,-0.41015 0.70311,-0.95702 0.70313,-1.64062 -2e-5,-0.63476 -0.23439,-1.14257 -0.70313,-1.52344 -0.459,-0.39062 -1.26954,-0.58593 -2.43164,-0.58594 l -3.36914,0 0,4.35059"
+                            style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+                            id="path3155"
+                            inkscape:connector-curvature="0" />
+                </g>
+                <g
+                        transform="matrix(0.8,0,0,0.8,125.0875,66.207045)"
+                        style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4701);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+                        id="text3191">
+                    <path
+                            d="m 614.87305,324.17786 7.36816,0 4.33594,7.25097 4.33594,-7.25097 7.32421,0 -8.3496,12.48047 0,8.99414 -6.6504,0 0,-8.99414 -8.36425,-12.48047"
+                            style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+                            id="path3152"
+                            inkscape:connector-curvature="0" />
+                </g>
+                <g
+                        transform="matrix(0.8,0,0,0.8,155.28437,37.707045)"
+                        style="font-size:30px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#f7f7f4;fill-opacity:1;stroke:none;display:inline;filter:url(#filter4697);font-family:Arial Black;-inkscape-font-specification:'Arial Black,'"
+                        id="text3179">
+                    <path
+                            d="m 766.49902,181.67786 7.30957,0 3.8086,6.60644 3.6914,-6.60644 7.23633,0 -6.67969,10.40039 7.30957,11.07422 -7.45605,0 -4.2334,-6.89942 -4.24805,6.89942 -7.4121,0 7.4121,-11.19141 -6.73828,-10.2832"
+                            style="font-weight:normal;-inkscape-font-specification:'Arial Black,'"
+                            id="path3161"
+                            inkscape:connector-curvature="0" />
+                </g>
+            </g>
         </svg>
 
     </body>


### PR DESCRIPTION
The controller svg uses flow text for the labels. Browsers can't handle this though. Thus, I converted the flow text to paths. Even though there is also the text which is supported by browsers, using paths provides the advantage that the client does not need to have the used font installed.