### PR TITLE
Chrome shortcut fix for gamepad

### DIFF
--- a/public/images/gamepad_icons/manifest.json
+++ b/public/images/gamepad_icons/manifest.json
@@ -38,7 +38,7 @@
       "density": "4.0"
     }
   ],
-  "start_url": "index.html",
+  "start_url": "/gamepad.html",
   "display": "standalone",
   "orientation": "landscape"
 }


### PR DESCRIPTION
This fixed a problem I was having creating and using a shortcut with the Chrome "Add to Home screen" button. This pull fixes issue #46 